### PR TITLE
Enable devTools only for local development

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,7 +6,13 @@ let win
 
 function createWindow () {
     // Create the browser window.
-  win = new BrowserWindow({width: 800, height: 600})
+  win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      devTools: (process.argv.indexOf('--enable-DevTools') != -1) ? false : true
+    }
+  })
 
     // and load the index.html of the app.
   win.loadFile('index.html')

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Kokomo. On demand. On your desktop.",
   "main": "main.js",
   "scripts": {
-    "start": "electron .",
+    "start": "electron . --enable-devTools",
     "build-all": "npm run build-darwin-x64",
     "build-darwin-x64": "./node_modules/.bin/electron-packager . Kokomo --platform=darwin --arch=x64 --overwrite --out=./build"
   },


### PR DESCRIPTION
This fixes: https://github.com/nodanaonlyzuul/kokomo-desktop/issues/10